### PR TITLE
fix: 이메일 인증 코드 요청 전 이메일 중복 검증 로직 추가

### DIFF
--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/api/EmailApiController.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/api/EmailApiController.java
@@ -58,7 +58,7 @@ public class EmailApiController {
 			.httpOnly(true)
 			.maxAge(300L)
 			.build();
-		
+
 		return ResponseEntity.noContent().header(HttpHeaders.SET_COOKIE, cookie.toString()).build();
 	}
 

--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/api/EmailApiController.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/api/EmailApiController.java
@@ -1,5 +1,9 @@
 package io.f12.notionlinkedblog.api;
 
+import static io.f12.notionlinkedblog.exceptions.ExceptionMessages.UserExceptionsMessages.*;
+
+import java.util.Optional;
+
 import javax.servlet.http.HttpSession;
 
 import org.springframework.http.HttpHeaders;
@@ -11,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import io.f12.notionlinkedblog.domain.user.User;
+import io.f12.notionlinkedblog.repository.user.UserDataRepository;
 import io.f12.notionlinkedblog.service.EmailSignupService;
 import io.f12.notionlinkedblog.web.argumentresolver.email.Email;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +28,7 @@ public class EmailApiController {
 	public static final String redisCookieName = "x-redis-id";
 	public static final String emailVerifiedAttr = "emailVerified";
 	private final EmailSignupService emailSignupService;
+	private final UserDataRepository userDataRepository;
 
 	@PostMapping("/code")
 	public ResponseEntity<String> verifyCode(
@@ -44,11 +51,21 @@ public class EmailApiController {
 
 	@PostMapping
 	public ResponseEntity<String> sendRandomCode(@Email String email) {
+		checkDuplicateEmail(email);
+
 		String redisId = emailSignupService.sendMail(email);
 		ResponseCookie cookie = ResponseCookie.from(redisCookieName, redisId)
 			.httpOnly(true)
 			.maxAge(300L)
 			.build();
+		
 		return ResponseEntity.noContent().header(HttpHeaders.SET_COOKIE, cookie.toString()).build();
+	}
+
+	private void checkDuplicateEmail(final String email) {
+		Optional<User> user = userDataRepository.findByEmail(email);
+		if (user.isPresent()) {
+			throw new IllegalArgumentException(EMAIL_ALREADY_EXIST);
+		}
 	}
 }

--- a/003 Code/BE/notion-linked-blog/src/main/resources/data.sql
+++ b/003 Code/BE/notion-linked-blog/src/main/resources/data.sql
@@ -1,4 +1,4 @@
 insert into users(id, username, email, password)
-values (1, 'test', 'test@gmail.com', '$2a$10$mLXRFrihpPDDc/iKr/Sqz.pcl6zqz45dyNCWhL8sCeZYo.jcZj1CW');
+values (999999, 'test', 'test@gmail.com', '$2a$10$mLXRFrihpPDDc/iKr/Sqz.pcl6zqz45dyNCWhL8sCeZYo.jcZj1CW');
 insert into posts(id, user_id, title, content)
-values (1, 1, 'testTitle', 'testContent');
+values (999999, 999999, 'testTitle', 'testContent');

--- a/003 Code/BE/notion-linked-blog/src/test/java/io/f12/notionlinkedblog/api/EmailApiControllerTests.java
+++ b/003 Code/BE/notion-linked-blog/src/test/java/io/f12/notionlinkedblog/api/EmailApiControllerTests.java
@@ -16,8 +16,10 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import io.f12.notionlinkedblog.domain.user.User;
 import io.f12.notionlinkedblog.domain.verification.EmailVerificationToken;
 import io.f12.notionlinkedblog.repository.redis.EmailVerificationTokenRepository;
+import io.f12.notionlinkedblog.repository.user.UserDataRepository;
 import io.f12.notionlinkedblog.security.service.SecureRandomService;
 import io.f12.notionlinkedblog.service.EmailSignupService;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +33,8 @@ class EmailApiControllerTests {
 	private MockMvc mockMvc;
 	@Autowired
 	private EmailVerificationTokenRepository emailVerificationTokenRepository;
+	@Autowired
+	private UserDataRepository userDataRepository;
 	@Autowired
 	private SecureRandomService secureRandomService;
 	@MockBean
@@ -147,6 +151,21 @@ class EmailApiControllerTests {
 		@Nested
 		@DisplayName("비정상 케이스")
 		class FailureCase {
+			@DisplayName("이메일이 중복되어 실패")
+			@Test
+			void duplicateEmail() throws Exception {
+				//given
+				final String alreadyExistingEmail = "hello@gmail.com";
+				userDataRepository.save(
+					User.builder().email(alreadyExistingEmail).password("1234").username("hello").build());
+
+				//when
+				ResultActions resultActions = mockMvc.perform(post("/api/email").content(alreadyExistingEmail));
+
+				//then
+				resultActions.andExpect(status().isBadRequest());
+			}
+
 			@DisplayName("이메일이 입력되지 않아 실패")
 			@Test
 			void isEmpty() throws Exception {


### PR DESCRIPTION
# What is this PR?🔍

- Jira Issues: [F12-60](https://come-capstone23-f12.atlassian.net/browse/F12-60)

## Changes📝

- 이메일 인증 코드 요청 전 이메일 중복 검사를 통해 사용자 편의 증대
- data.sql에서 데이터를 직접 넣어서 PK를 1로 했더니 e2e 테스트 중 회원가입 시 키 중복 문제가 발생하여 999999로 변경

## Test Checklist✅

- [x] 이메일 중복 시 400(Bad Request) 응답
