### PR TITLE
fix: 로그인 시 프론트에 유저 정보를 내려주기 위해 로그인 정보 저장 관련 

### DIFF
--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/api/post/PostApiController.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/api/post/PostApiController.java
@@ -35,7 +35,7 @@ public class PostApiController {
 	@ResponseStatus(HttpStatus.CREATED)
 	public PostSearchDto createPost(@AuthenticationPrincipal LoginUser loginUser,
 		@RequestBody PostCreateDto postCreateDto) {
-		return postService.createPost(loginUser.getId(), postCreateDto);
+		return postService.createPost(loginUser.getUser().getId(), postCreateDto);
 	}
 
 	@GetMapping("/{id}")
@@ -57,13 +57,13 @@ public class PostApiController {
 	@ResponseStatus(HttpStatus.FOUND)
 	public String editPost(@PathVariable("id") Long postId, @AuthenticationPrincipal LoginUser loginUser,
 		@RequestBody PostEditDto editInfo) {
-		postService.editPost(postId, loginUser.getId(), editInfo);
+		postService.editPost(postId, loginUser.getUser().getId(), editInfo);
 		return Endpoint.Api.POST + "/" + postId;
 	}
 
 	@DeleteMapping("/{id}")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public void deletePost(@PathVariable("id") Long postId, @AuthenticationPrincipal LoginUser loginUser) {
-		postService.removePost(postId, loginUser.getId());
+		postService.removePost(postId, loginUser.getUser().getId());
 	}
 }

--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/api/user/UserApiController.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/api/user/UserApiController.java
@@ -76,7 +76,7 @@ public class UserApiController {
 	}
 
 	private void checkSameUser(Long id, LoginUser loginUser) {
-		if (!id.equals(loginUser.getId())) {
+		if (!id.equals(loginUser.getUser().getId())) {
 			throw new AccessDeniedException("데이터를 찾지 못했습니다");
 		}
 	}

--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/security/login/ajax/dto/AjaxLoginSuccessDto.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/security/login/ajax/dto/AjaxLoginSuccessDto.java
@@ -8,15 +8,15 @@ import lombok.ToString;
 @EqualsAndHashCode
 @ToString
 public class AjaxLoginSuccessDto {
-	private final String id;
+	private final UserWithoutPassword user;
 	private final String redirectUrl;
 
-	private AjaxLoginSuccessDto(String id, String redirectUrl) {
-		this.id = id;
+	private AjaxLoginSuccessDto(UserWithoutPassword userWithoutPassword, String redirectUrl) {
+		this.user = userWithoutPassword;
 		this.redirectUrl = redirectUrl;
 	}
 
-	public static AjaxLoginSuccessDto of(String id, String redirectUrl) {
-		return new AjaxLoginSuccessDto(id, redirectUrl);
+	public static AjaxLoginSuccessDto of(UserWithoutPassword userWithoutPassword, String redirectUrl) {
+		return new AjaxLoginSuccessDto(userWithoutPassword, redirectUrl);
 	}
 }

--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/security/login/ajax/dto/LoginUser.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/security/login/ajax/dto/LoginUser.java
@@ -7,45 +7,41 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.SpringSecurityCoreVersion;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import io.f12.notionlinkedblog.domain.user.User;
 import lombok.Getter;
 
 @Getter
 public class LoginUser implements UserDetails, Serializable {
 	private static final long serialVersionUID = SpringSecurityCoreVersion.SERIAL_VERSION_UID;
-	private final Long id;
-	private final String email;
-	private final String password;
+	private final User user;
 	private final boolean isAccountNonExpired = true;
 	private final boolean isAccountNonLocked = true;
 	private final boolean isCredentialsNonExpired = true;
 	private final boolean isEnabled = true;
 	private final Collection<? extends GrantedAuthority> authorities;
 
-	private LoginUser(Long id, String email, String password, Collection<? extends GrantedAuthority> authorities) {
-		this.id = id;
-		this.email = email;
-		this.password = password;
+	private LoginUser(User user, Collection<? extends GrantedAuthority> authorities) {
+		this.user = user;
 		this.authorities = authorities;
 	}
 
-	public static LoginUser of(Long id, String email, String password,
-		Collection<? extends GrantedAuthority> authorities) {
-		return new LoginUser(id, email, password, authorities);
+	public static LoginUser of(User user, Collection<? extends GrantedAuthority> authorities) {
+		return new LoginUser(user, authorities);
+	}
+
+	@Override
+	public String getPassword() {
+		return user.getPassword();
+	}
+
+	@Override
+	public String getUsername() {
+		return user.getUsername();
 	}
 
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
 		return authorities;
-	}
-
-	@Override
-	public String getPassword() {
-		return password;
-	}
-
-	@Override
-	public String getUsername() {
-		return email;
 	}
 
 	@Override

--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/security/login/ajax/dto/UserWithoutPassword.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/security/login/ajax/dto/UserWithoutPassword.java
@@ -1,0 +1,35 @@
+package io.f12.notionlinkedblog.security.login.ajax.dto;
+
+import io.f12.notionlinkedblog.domain.user.User;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+public class UserWithoutPassword {
+	private final Long id;
+	private final String username;
+	private final String email;
+	private final String profile;
+	private final String introduction;
+	private final String blogTitle;
+	private final String githubLink;
+	private final String instagramLink;
+
+	private UserWithoutPassword(User user) {
+		this.id = user.getId();
+		this.username = user.getUsername();
+		this.email = user.getEmail();
+		this.profile = user.getProfile();
+		this.introduction = user.getIntroduction();
+		this.blogTitle = user.getBlogTitle();
+		this.githubLink = user.getGithubLink();
+		this.instagramLink = user.getInstagramLink();
+	}
+
+	public static UserWithoutPassword of(User user) {
+		return new UserWithoutPassword(user);
+	}
+}

--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/security/login/ajax/handler/AjaxAuthenticationSuccessHandler.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/security/login/ajax/handler/AjaxAuthenticationSuccessHandler.java
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.f12.notionlinkedblog.security.login.ajax.dto.AjaxLoginSuccessDto;
 import io.f12.notionlinkedblog.security.login.ajax.dto.LoginUser;
+import io.f12.notionlinkedblog.security.login.ajax.dto.UserWithoutPassword;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -45,7 +46,7 @@ public class AjaxAuthenticationSuccessHandler extends SimpleUrlAuthenticationSuc
 
 	private AjaxLoginSuccessDto getAjaxLoginSuccessDto(Authentication authentication, String redirectUrl) {
 		LoginUser principal = (LoginUser)authentication.getPrincipal();
-		String id = Long.toString(principal.getId());
-		return AjaxLoginSuccessDto.of(id, redirectUrl);
+		UserWithoutPassword userWithoutPassword = UserWithoutPassword.of(principal.getUser());
+		return AjaxLoginSuccessDto.of(userWithoutPassword, redirectUrl);
 	}
 }

--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/security/login/ajax/service/EmailUserDetailsService.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/security/login/ajax/service/EmailUserDetailsService.java
@@ -23,7 +23,6 @@ public class EmailUserDetailsService implements UserDetailsService {
 	@Override
 	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
 		User user = userDataRepository.findByEmail(email).orElseThrow(() -> new EmailNotFoundException(email));
-		return LoginUser.of(user.getId(), user.getEmail(), user.getPassword(),
-			Set.of(new SimpleGrantedAuthority("ROLE_USER")));
+		return LoginUser.of(user, Set.of(new SimpleGrantedAuthority("ROLE_USER")));
 	}
 }

--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/security/login/ajax/token/AjaxEmailPasswordAuthenticationToken.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/security/login/ajax/token/AjaxEmailPasswordAuthenticationToken.java
@@ -43,7 +43,7 @@ public class AjaxEmailPasswordAuthenticationToken extends AbstractAuthentication
 
 	@Override
 	public String getName() {
-		return ((LoginUser)principal).getEmail();
+		return ((LoginUser)principal).getUser().getEmail();
 	}
 
 	@Override

--- a/003 Code/BE/notion-linked-blog/src/test/java/io/f12/notionlinkedblog/security/login/ajax/filter/AjaxEmailPasswordAuthenticationFilterTests.java
+++ b/003 Code/BE/notion-linked-blog/src/test/java/io/f12/notionlinkedblog/security/login/ajax/filter/AjaxEmailPasswordAuthenticationFilterTests.java
@@ -73,7 +73,7 @@ class AjaxEmailPasswordAuthenticationFilterTests extends DummyObject {
 				//then
 				resultActions
 					.andExpect(status().isOk())
-					.andExpect(jsonPath("$.id").exists())
+					.andExpect(jsonPath("$.user").exists())
 					.andExpect(jsonPath("$.redirectUrl").exists());
 			}
 		}


### PR DESCRIPTION
# What is this PR?🔍

- Jira Issues: [F12-61](https://come-capstone23-f12.atlassian.net/jira/software/projects/F12/boards/1?selectedIssue=F12-61)

## Changes📝

요약글

- LoginUser의 id, email, password 대신 User 객체를 주입하도록 변경했습니다.
- AjaxLoginSuccessDto의 id가 보다 많은 유저 정보를 제공하기 위해 UserWithoutPassword로 변경되었습니다.

## Test Checklist✅

- [x] 이메일 기반 로그인 성공
