### PR TITLE
fix: Post 생성 시 잘못된 HttpMethod 변경

### DIFF
--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/api/post/PostApiController.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/api/post/PostApiController.java
@@ -8,6 +8,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,7 +32,7 @@ public class PostApiController {
 	private final PostService postService;
 
 	//TODO: 현재 Series 기능 미포함
-	@PutMapping
+	@PostMapping
 	@ResponseStatus(HttpStatus.CREATED)
 	public PostSearchDto createPost(@AuthenticationPrincipal LoginUser loginUser,
 		@RequestBody PostCreateDto postCreateDto) {

--- a/003 Code/BE/notion-linked-blog/src/test/java/io/f12/notionlinkedblog/api/post/PostApiControllerTest.java
+++ b/003 Code/BE/notion-linked-blog/src/test/java/io/f12/notionlinkedblog/api/post/PostApiControllerTest.java
@@ -94,7 +94,7 @@ class PostApiControllerTest {
 
 			//when
 			ResultActions resultActions = mockMvc.perform(
-				put(url)
+				post(url)
 					.contentType(MediaType.APPLICATION_JSON)
 					.session(mockHttpSession)
 					.content(requestBody)


### PR DESCRIPTION
# What is this PR?🔍

- Jira Issues: [F12-66](https://come-capstone23-f12.atlassian.net/jira/software/projects/F12/boards/1?selectedIssue=F12-66)
- NotionApiSheet:[노션](https://www.notion.so/jeidiiy/API-7c2a9051ecbc4f9e8e4d26b6d550a03f?pvs=4)

## Changes📝

요약글: Post 생성시 Api Method 가 PUT 으로 잘못 설정되어있던 부분 POST 로 변경
- PostApiController 변경
- Controller 테스트시 요청 PUT -> POST 로 변경

## Test Checklist✅

- [x] PostApiControllerTest
