### PR TITLE
fix: Dotenv 설정이 제외되던 오류 해결

### DIFF
--- a/003 Code/FE/notion-linked-blog/next.config.js
+++ b/003 Code/FE/notion-linked-blog/next.config.js
@@ -2,12 +2,12 @@
 const Dotenv = require("dotenv-webpack");
 const removeImports = require("next-remove-imports");
 
-const nextConfig = removeImports({
+const nextConfig = removeImports({});
+
+module.exports = nextConfig({
 	reactStrictMode: true,
 	webpack: config => {
 		config.plugins.push(new Dotenv({silent: true}));
 		return config;
 	},
 });
-
-module.exports = nextConfig;


### PR DESCRIPTION
# What is this PR?🔍

- Jira Issues: [F12-77](https://come-capstone23-f12.atlassian.net/jira/software/projects/F12/boards/1?selectedIssue=F12-77)

## Changes📝

dotenv가 제대로 동작하도록 next.config.js를 수정했습니다.

- removeImports를 적용한 후에 프론트엔드에서 api의 url에 undefined가 들어가는 것을 확인했습니다.
- dotenv가 적용되지 않는다는 것을 알고 next-remove-imports 공식 문서에서 정확한 사용법을 확인하고 적용했습니다.
