### PR TITLE
fix: 양방향 연관관계 설정 오류 해결

### DIFF
--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/domain/post/Post.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/domain/post/Post.java
@@ -50,7 +50,7 @@ public class Post extends PostTimeEntity {
 	@NotNull
 	private User user;
 
-	@OneToMany(mappedBy = "id", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Comments> comments = new ArrayList<>();
 
 	@NotBlank

--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/domain/user/User.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/domain/user/User.java
@@ -36,10 +36,10 @@ public class User extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "user_seq_generator")
 	private Long id;
 
-	@OneToMany(mappedBy = "id")
+	@OneToMany(mappedBy = "user")
 	private List<Post> posts = new ArrayList<>();
 
-	@OneToMany(mappedBy = "id")
+	@OneToMany(mappedBy = "user")
 	private List<Comments> comments = new ArrayList<>();
 
 	@Column(nullable = false)


### PR DESCRIPTION
# What is this PR?🔍

- Jira Issues:[F12-79](https://come-capstone23-f12.atlassian.net/jira/software/projects/F12/boards/1?selectedIssue=F12-79)

## Changes📝

 User, Post 에서 연관관계 설정 오류(mappedBy 뒤에 join 한 테이블의 필드명을 써야함)로 인한 오류 해결

- User의 posts, comments 필드 연관관계 재설정
- Posts의 comments 필드 연관관계 재설정
