### PR TITLE
refactor: 401, 404에 대한 중복 코드를 Reflection을 활용하여 제거

### DIFF
--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/aop/exception/DefaultRestControllerAdvice.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/aop/exception/DefaultRestControllerAdvice.java
@@ -10,7 +10,9 @@ import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 import io.f12.notionlinkedblog.domain.common.CommonErrorResponse;
+import io.swagger.v3.oas.annotations.Hidden;
 
+@Hidden
 @RestControllerAdvice
 public class DefaultRestControllerAdvice {
 

--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/api/EmailApiController.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/api/EmailApiController.java
@@ -7,18 +7,21 @@ import java.util.Optional;
 import javax.servlet.http.HttpSession;
 
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.f12.notionlinkedblog.domain.user.User;
 import io.f12.notionlinkedblog.repository.user.UserDataRepository;
 import io.f12.notionlinkedblog.service.EmailSignupService;
 import io.f12.notionlinkedblog.web.argumentresolver.email.Email;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -31,6 +34,8 @@ public class EmailApiController {
 	private final UserDataRepository userDataRepository;
 
 	@PostMapping("/code")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@Operation(summary = "인증 코드 검증", description = "유저가 전송한 인증 코드에 대한 유효성을 검증합니다.")
 	public ResponseEntity<String> verifyCode(
 		HttpSession session, @CookieValue(redisCookieName) String redisId, @RequestBody String code) {
 		verifyCodeElseThrowIllegalArgumentException(redisId, code);
@@ -50,6 +55,7 @@ public class EmailApiController {
 	}
 
 	@PostMapping
+	@ResponseStatus(HttpStatus.NO_CONTENT)
 	public ResponseEntity<String> sendRandomCode(@Email String email) {
 		checkDuplicateEmail(email);
 

--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/api/comments/CommentsApiController.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/api/comments/CommentsApiController.java
@@ -21,8 +21,6 @@ import io.f12.notionlinkedblog.api.common.Endpoint;
 import io.f12.notionlinkedblog.domain.comments.dto.CommentSearchDto;
 import io.f12.notionlinkedblog.domain.comments.dto.CreateCommentDto;
 import io.f12.notionlinkedblog.domain.comments.dto.EditCommentDto;
-import io.f12.notionlinkedblog.domain.common.CommonErrorResponse;
-import io.f12.notionlinkedblog.security.common.dto.AuthenticationFailureDto;
 import io.f12.notionlinkedblog.security.login.ajax.dto.LoginUser;
 import io.f12.notionlinkedblog.service.comments.CommentsService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -47,12 +45,6 @@ public class CommentsApiController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "201", description = "회원 정보변경 성공",
 			content = @Content(mediaType = APPLICATION_JSON_VALUE)),
-		@ApiResponse(responseCode = "401", description = "회원 미 로그인",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = AuthenticationFailureDto.class))),
-		@ApiResponse(responseCode = "404", description = "존재하지 않는 리소스(댓글) 접근",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = AuthenticationFailureDto.class)))
 	})
 	// TODO: 추후 리턴타입 감싸기 필요
 	public List<CommentSearchDto> getComments(@PathVariable("id") Long postId) {
@@ -65,22 +57,7 @@ public class CommentsApiController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "201", description = "회원 정보변경 성공",
 			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommentSearchDto.class))),
-		@ApiResponse(responseCode = "401", description = "회원 미 로그인",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = AuthenticationFailureDto.class))),
-		@ApiResponse(responseCode = "404", description = "존재하지 않는 리소스(포스트) 접근",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommonErrorResponse.class))),
-		@ApiResponse(responseCode = "404", description = "존재하지 않는 리소스(DB에 저장된 유저) 접근",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommonErrorResponse.class))),
-		@ApiResponse(responseCode = "404", description = "존재하지 않는 리소스(포스트) 접근",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommonErrorResponse.class))),
-		@ApiResponse(responseCode = "404", description = "존재하지 않는 리소스(댓글, 부모댓글 ID 불일치) 접근",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommonErrorResponse.class)))
+				schema = @Schema(implementation = CommentSearchDto.class)))
 	})
 	public CommentSearchDto createComments(@PathVariable("id") Long postId,
 		@Parameter(hidden = true) @AuthenticationPrincipal LoginUser loginUser,
@@ -94,16 +71,7 @@ public class CommentsApiController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "302", description = "댓글 변경 성공",
 			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommentSearchDto.class))),
-		@ApiResponse(responseCode = "401", description = "회원 미 로그인",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = AuthenticationFailureDto.class))),
-		@ApiResponse(responseCode = "404", description = "존재하지 않는 리소스(댓글) 접근",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommonErrorResponse.class))),
-		@ApiResponse(responseCode = "401", description = "댓글 수정자와 댓글 소유자 불일치",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommonErrorResponse.class)))
+				schema = @Schema(implementation = CommentSearchDto.class)))
 	})
 	public CommentSearchDto editComments(@PathVariable("id") Long commentId,
 		@Parameter(hidden = true) @AuthenticationPrincipal LoginUser loginUser,
@@ -115,20 +83,10 @@ public class CommentsApiController {
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	@Operation(summary = "댓글 삭제", description = "commentId에 해당하는 댓글 삭제")
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "204", description = "댓글 삭제 성공"),
-		@ApiResponse(responseCode = "401", description = "회원 미 로그인",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = AuthenticationFailureDto.class))),
-		@ApiResponse(responseCode = "404", description = "존재하지 않는 리소스(댓글) 접근",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommonErrorResponse.class))),
-		@ApiResponse(responseCode = "301", description = "댓글 삭제자와 댓글 소유자 불일치",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommonErrorResponse.class)))
+		@ApiResponse(responseCode = "204", description = "댓글 삭제 성공")
 	})
 	public void removeComments(@PathVariable("id") Long commentId,
 		@Parameter(hidden = true) @AuthenticationPrincipal LoginUser loginUser) {
 		commentsService.removeComment(commentId, loginUser.getUser().getId());
 	}
-
 }

--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/api/post/PostApiController.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/api/post/PostApiController.java
@@ -31,7 +31,6 @@ import io.f12.notionlinkedblog.domain.post.dto.PostSearchDto;
 import io.f12.notionlinkedblog.domain.post.dto.PostSearchResponseDto;
 import io.f12.notionlinkedblog.domain.post.dto.SearchRequestDto;
 import io.f12.notionlinkedblog.domain.post.dto.ThumbnailReturnDto;
-import io.f12.notionlinkedblog.security.common.dto.AuthenticationFailureDto;
 import io.f12.notionlinkedblog.security.login.ajax.dto.LoginUser;
 import io.f12.notionlinkedblog.service.post.PostService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -60,13 +59,7 @@ public class PostApiController {
 			content = @Content(mediaType = APPLICATION_JSON_VALUE,
 				schema = @Schema(implementation = PostSearchDto.class,
 					description = "requestThumbnailLink 은 해당 API 로 이미지를 다시 요청해야 합니다"))),
-		@ApiResponse(responseCode = "401", description = "회원 미 로그인",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = AuthenticationFailureDto.class))),
-		@ApiResponse(responseCode = "404", description = "회원 데이터 미존재",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommonErrorResponse.class))),
-		@ApiResponse(responseCode = "404", description = "isPublic 값이 0, 1 이 아닌경우",
+		@ApiResponse(responseCode = "400", description = "isPublic 값이 0, 1 이 아닌경우",
 			content = @Content(mediaType = APPLICATION_JSON_VALUE,
 				schema = @Schema(implementation = CommonErrorResponse.class)))
 	})
@@ -89,9 +82,6 @@ public class PostApiController {
 				schema = @Schema(implementation = PostSearchDto.class,
 					description = "requestThumbnailLink 은 해당 API 로 이미지를 다시 요청해야 합니다"))),
 		@ApiResponse(responseCode = "400", description = "RequestDto 미존재",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommonErrorResponse.class))),
-		@ApiResponse(responseCode = "404", description = "Post 데이터 미존재",
 			content = @Content(mediaType = APPLICATION_JSON_VALUE,
 				schema = @Schema(implementation = CommonErrorResponse.class))),
 		@ApiResponse(responseCode = "415", description = "필수 데이터 미존재",
@@ -160,16 +150,7 @@ public class PostApiController {
 	@ResponseStatus(HttpStatus.FOUND)
 	@Operation(summary = "포스트 수정", description = "id 에 해당하는 포스트 수정")
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "302", description = "포스트 수정 성공"),
-		@ApiResponse(responseCode = "401", description = "회원 미 로그인",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = AuthenticationFailureDto.class))),
-		@ApiResponse(responseCode = "404", description = "포스트 데이터 미존재",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommonErrorResponse.class))),
-		@ApiResponse(responseCode = "401", description = "작성자와 수정시도자 불일치",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommonErrorResponse.class)))
+		@ApiResponse(responseCode = "302", description = "포스트 수정 성공")
 	})
 	//TODO: 추후 JSON 으로 리턴타입 변경 필요
 	public String editPost(@PathVariable("id") Long postId,
@@ -183,16 +164,7 @@ public class PostApiController {
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	@Operation(summary = "포스트 삭제", description = "id에 해당하는 포스트 삭제")
 	@ApiResponses(value = {
-		@ApiResponse(responseCode = "204", description = "포스트 삭제 성공"),
-		@ApiResponse(responseCode = "401", description = "회원 미 로그인",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = AuthenticationFailureDto.class))),
-		@ApiResponse(responseCode = "404", description = "포스트 데이터 미존재",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommonErrorResponse.class))),
-		@ApiResponse(responseCode = "401", description = "작성자와 삭제시도자 불일치",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommonErrorResponse.class)))
+		@ApiResponse(responseCode = "204", description = "포스트 삭제 성공")
 	})
 	public void deletePost(@PathVariable("id") Long postId,
 		@Parameter(hidden = true) @AuthenticationPrincipal LoginUser loginUser) {
@@ -204,15 +176,6 @@ public class PostApiController {
 	@Operation(summary = "해당하는 Post 에 Like 를 추가/삭제 합니다")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "201", description = "Like 상태 변경 성공"),
-		@ApiResponse(responseCode = "401", description = "회원 미 로그인",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = AuthenticationFailureDto.class))),
-		@ApiResponse(responseCode = "404", description = "포스트 데이터 미존재",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommonErrorResponse.class))),
-		@ApiResponse(responseCode = "404", description = "유저 데이터 미존재(DB에 미존재)",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommonErrorResponse.class)))
 	})
 	public void addLikeToPost(@PathVariable Long postId,
 		@Parameter(hidden = true) @AuthenticationPrincipal LoginUser loginUser) {
@@ -224,9 +187,6 @@ public class PostApiController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "200", description = "이미지 가져오기 성공",
 			content = @Content(mediaType = "image/*")),
-		@ApiResponse(responseCode = "404", description = "이미지 미존재",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommonErrorResponse.class))),
 		@ApiResponse(responseCode = "401", description = "DB에 이미지 이름 저장 오류, 문의 요망",
 			content = @Content(mediaType = APPLICATION_JSON_VALUE,
 				schema = @Schema(implementation = CommonErrorResponse.class)))

--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/api/user/UserApiController.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/api/user/UserApiController.java
@@ -22,12 +22,10 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.f12.notionlinkedblog.api.common.Endpoint;
-import io.f12.notionlinkedblog.domain.common.CommonErrorResponse;
 import io.f12.notionlinkedblog.domain.user.dto.info.UserEditDto;
 import io.f12.notionlinkedblog.domain.user.dto.info.UserSearchDto;
 import io.f12.notionlinkedblog.domain.user.dto.signup.UserSignupRequestDto;
 import io.f12.notionlinkedblog.domain.user.dto.signup.UserSignupResponseDto;
-import io.f12.notionlinkedblog.security.common.dto.AuthenticationFailureDto;
 import io.f12.notionlinkedblog.security.login.ajax.dto.LoginUser;
 import io.f12.notionlinkedblog.service.user.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -82,13 +80,7 @@ public class UserApiController {
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "201", description = "회원 정보변경 성공",
 			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = UserSearchDto.class))),
-		@ApiResponse(responseCode = "401", description = "회원 미 로그인",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = AuthenticationFailureDto.class))),
-		@ApiResponse(responseCode = "404", description = "존재하지 않는 리소스(유저) 접근",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommonErrorResponse.class)))
+				schema = @Schema(implementation = UserSearchDto.class)))
 	})
 	public void editUserInfo(@PathVariable Long id,
 		@Parameter(hidden = true) @AuthenticationPrincipal LoginUser loginUser,
@@ -102,13 +94,7 @@ public class UserApiController {
 	@Operation(summary = "회원 정보 삭제", description = "id에 해당하는 사용자의 정보를 삭제합니다.")
 	@ApiResponses(value = {
 		@ApiResponse(responseCode = "204", description = "회원 삭제 성공",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE)),
-		@ApiResponse(responseCode = "401", description = "회원 미 로그인",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = AuthenticationFailureDto.class))),
-		@ApiResponse(responseCode = "404", description = "존재하지 않는 리소스(유저) 접근",
-			content = @Content(mediaType = APPLICATION_JSON_VALUE,
-				schema = @Schema(implementation = CommonErrorResponse.class)))
+			content = @Content(mediaType = APPLICATION_JSON_VALUE))
 	})
 	public void deleteUser(@PathVariable Long id,
 		@Parameter(hidden = true) @AuthenticationPrincipal LoginUser loginUser) {

--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/config/SwaggerConfig.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/config/SwaggerConfig.java
@@ -26,6 +26,7 @@ import org.springframework.security.web.context.AbstractSecurityWebApplicationIn
 import org.springframework.util.ReflectionUtils;
 
 import io.f12.notionlinkedblog.domain.common.CommonErrorResponse;
+import io.f12.notionlinkedblog.security.common.dto.AuthenticationFailureDto;
 import io.f12.notionlinkedblog.security.login.ajax.dto.LoginUser;
 import io.f12.notionlinkedblog.security.login.ajax.filter.AjaxEmailPasswordAuthenticationFilter;
 import io.f12.notionlinkedblog.security.login.check.filter.LoginStatusCheckingFilter;
@@ -83,10 +84,10 @@ public class SwaggerConfig {
 	}
 
 	private void addNotFoundApiResponse(Operation operation) {
-		String statusCode = "405";
+		String statusCode = "404";
 		String description = "존재하지 않는 자원 접근";
 
-		setOperation(operation, statusCode, description, APPLICATION_JSON_VALUE);
+		setOperation(operation, statusCode, description, APPLICATION_JSON_VALUE, CommonErrorResponse.class);
 	}
 
 	private void addUnAuthorizedApiResponse(Operation operation, List<Class<?>> params) {
@@ -94,22 +95,23 @@ public class SwaggerConfig {
 			String statusCode = "401";
 			String description = "인증 실패";
 
-			setOperation(operation, statusCode, description, APPLICATION_JSON_VALUE);
+			setOperation(operation, statusCode, description, APPLICATION_JSON_VALUE, AuthenticationFailureDto.class);
 		}
 	}
 
-	private void setOperation(Operation operation, String statusCode, String description, String mediaTypeName) {
-		Schema<?> notFoundSchema;
+	private void setOperation(
+		Operation operation, String statusCode, String description, String mediaTypeName, Class<?> clazz) {
+		Schema<?> schema;
 		MediaType mediaType = new MediaType();
 
 		Content content = new Content();
 		content.addMediaType(mediaTypeName, mediaType);
 		try {
-			notFoundSchema = createSchemaWithDefaultType(CommonErrorResponse.class);
+			schema = createSchemaWithDefaultType(clazz);
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}
-		mediaType.setSchema(notFoundSchema);
+		mediaType.setSchema(schema);
 
 		ApiResponse notFoundApiResponse = new ApiResponse()
 			.description(description)

--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/config/SwaggerConfig.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/config/SwaggerConfig.java
@@ -1,11 +1,21 @@
 package io.f12.notionlinkedblog.config;
 
 import static io.f12.notionlinkedblog.api.common.Endpoint.Api.*;
+import static org.springframework.http.MediaType.*;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 import org.springdoc.core.GroupedOpenApi;
 import org.springdoc.core.customizers.OpenApiCustomiser;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,7 +23,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.context.AbstractSecurityWebApplicationInitializer;
+import org.springframework.util.ReflectionUtils;
 
+import io.f12.notionlinkedblog.domain.common.CommonErrorResponse;
+import io.f12.notionlinkedblog.security.login.ajax.dto.LoginUser;
 import io.f12.notionlinkedblog.security.login.ajax.filter.AjaxEmailPasswordAuthenticationFilter;
 import io.f12.notionlinkedblog.security.login.check.filter.LoginStatusCheckingFilter;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -43,6 +56,7 @@ public class SwaggerConfig {
 			.pathsToMatch("/api/**")
 			.addOpenApiCustomiser(springSecurityLoginEndpointCustomiser())
 			.addOpenApiCustomiser(loginStatusCheckingEndpointCustomiser())
+			.addOperationCustomizer(springSecurityOperationCustomizer())
 			.build();
 	}
 
@@ -53,6 +67,125 @@ public class SwaggerConfig {
 				.title("API 문서")
 				.version("0.0.1")
 				.description("API 문서입니다."));
+	}
+
+	@Bean
+	public OperationCustomizer springSecurityOperationCustomizer() {
+		return (operation, handlerMethod) -> {
+			Method method = handlerMethod.getMethod();
+			List<Class<?>> params = Arrays.asList(method.getParameterTypes());
+
+			addUnAuthorizedApiResponse(operation, params);
+			addNotFoundApiResponse(operation);
+
+			return operation;
+		};
+	}
+
+	private void addNotFoundApiResponse(Operation operation) {
+		String statusCode = "405";
+		String description = "존재하지 않는 자원 접근";
+
+		setOperation(operation, statusCode, description, APPLICATION_JSON_VALUE);
+	}
+
+	private void addUnAuthorizedApiResponse(Operation operation, List<Class<?>> params) {
+		if (params.contains(LoginUser.class)) {
+			String statusCode = "401";
+			String description = "인증 실패";
+
+			setOperation(operation, statusCode, description, APPLICATION_JSON_VALUE);
+		}
+	}
+
+	private void setOperation(Operation operation, String statusCode, String description, String mediaTypeName) {
+		Schema<?> notFoundSchema;
+		MediaType mediaType = new MediaType();
+
+		Content content = new Content();
+		content.addMediaType(mediaTypeName, mediaType);
+		try {
+			notFoundSchema = createSchemaWithDefaultType(CommonErrorResponse.class);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+		mediaType.setSchema(notFoundSchema);
+
+		ApiResponse notFoundApiResponse = new ApiResponse()
+			.description(description)
+			.content(content);
+		operation.getResponses().addApiResponse(statusCode, notFoundApiResponse);
+	}
+
+	/**
+	 * 파라미터 타입으로 인스턴스를 생성하여 반환합니다.
+	 * 만약 클래스에 public 기본 생성자가 없는 경우 싱글톤 클래스로 간주합니다.
+	 * 이 경우 클래스에 정의된 instance 필드를 참조합니다. 따라서 싱글톤 클래스를 사용할 경우 instance 필드에 인스턴스가 존재해야 합니다.
+	 * @author JIYONG JUNG
+	 * @param clazz Class<?>
+	 * @return Object
+	 */
+	private Object getInstance(Class<?> clazz) throws
+		InstantiationException,
+		IllegalAccessException,
+		InvocationTargetException,
+		NoSuchFieldException {
+		Object instance = null;
+		try {
+			Constructor<?> constructor = clazz.getConstructor();
+			instance = constructor.newInstance();
+		} catch (NoSuchMethodException e) {
+			Field field = clazz.getDeclaredField("instance");
+			field.setAccessible(true);
+			int modifiers = field.getModifiers();
+			if (Modifier.isStatic(modifiers) && Modifier.isFinal(modifiers)) {
+				instance = field.get(null);
+			}
+		}
+		return instance;
+	}
+
+	/**
+	 * final 및 static이 적용되지 않고 getter가 존재하는 string 타입의 필드에 대하여 "string" 문자열을 주입한 Schema를 반환합니다.
+	 * primitive 타입은 기본값이 들어갑니다.
+	 * String이 아닌 객체 타입에 대해서는 동작하지 않습니다.
+	 * @author JIYONG JUNG
+	 * @param clazz Class<?>
+	 * @return Schema<?>
+	 */
+	private Schema<?> createSchemaWithDefaultType(Class<?> clazz) throws
+		InvocationTargetException,
+		InstantiationException,
+		IllegalAccessException,
+		ClassNotFoundException, NoSuchFieldException {
+		Schema<?> schema = new Schema<>();
+		Class.forName(clazz.getName());
+
+		Object instance = getInstance(clazz);
+
+		Field[] declaredFields = clazz.getDeclaredFields();
+
+		for (Field field : declaredFields) {
+			field.setAccessible(true);
+			int modifiers = field.getModifiers();
+			if (!Modifier.isStatic(modifiers) && field.getType().isAssignableFrom(String.class)) {
+				ArrayList<Method> declaredMethods = new ArrayList<>(Arrays.asList(clazz.getDeclaredMethods()));
+				String fieldName = field.getName();
+				String getter = "get" + fieldName.substring(0, 1).toUpperCase() + fieldName.substring(1);
+				for (Method method : declaredMethods) {
+					method.setAccessible(true);
+					String methodName = method.getName();
+					if (methodName.equals(getter)) {
+						ReflectionUtils.setField(field, instance, field.getType().getSimpleName().toLowerCase());
+						declaredMethods.remove(method);
+						break;
+					}
+				}
+			}
+		}
+
+		schema.setDefault(instance);
+		return schema;
 	}
 
 	@Bean
@@ -74,7 +207,7 @@ public class SwaggerConfig {
 						.addProperties(ajaxEmailPasswordAuthenticationFilter.getPasswordParameter(),
 							new StringSchema());
 					RequestBody requestBody = new RequestBody().content(
-						new Content().addMediaType(org.springframework.http.MediaType.APPLICATION_JSON_VALUE,
+						new Content().addMediaType(APPLICATION_JSON_VALUE,
 							new MediaType().schema(schema)));
 					operation.requestBody(requestBody);
 					ApiResponses apiResponses = new ApiResponses();

--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/domain/common/CommonErrorResponse.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/domain/common/CommonErrorResponse.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class CommonErrorResponse {
-	String errorMassage;
-	int errorCode;
+	private String errorMassage;
+	private int errorCode;
 }

--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/security/config/SecurityConfig.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/security/config/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
 			// swagger 문서 접근 허용
 			.antMatchers("/swagger-ui/**").permitAll()
 			.antMatchers("/v3/api-docs/**").permitAll()
+			.antMatchers("/h2-console/**").permitAll()
 			.anyRequest().authenticated();
 
 		http

--- a/003 Code/BE/notion-linked-blog/src/main/resources/application.yml
+++ b/003 Code/BE/notion-linked-blog/src/main/resources/application.yml
@@ -5,6 +5,9 @@ server:
       force-response: true
 
 spring:
+  h2:
+    console:
+      enabled: true
   sql:
     init:
       mode: embedded #data.sql(초기화) 실행(memory, embedded 모드에서만)

--- a/003 Code/BE/notion-linked-blog/src/main/resources/data.sql
+++ b/003 Code/BE/notion-linked-blog/src/main/resources/data.sql
@@ -2,16 +2,21 @@
 insert into users(id, username, email, password)
 values (999999, 'test', 'test@gmail.com', '$2a$10$mLXRFrihpPDDc/iKr/Sqz.pcl6zqz45dyNCWhL8sCeZYo.jcZj1CW');
 -- 포스트 --
-insert into posts(id, user_id, title, content, view_count, created_at, is_public) --포스트 1번, 후순위--
-values (999999, 999999, 'testTitle', 'testContent', 0, FORMATDATETIME('2023-05-06 00:00:00', 'yyyy-MM-dd'), true);
-insert into posts(id, user_id, title, content, view_count, created_at, is_public) --포스트 2번--
-values (1000000, 999999, 'testTitle2', 'testContent2', 100, FORMATDATETIME('2023-05-06 00:00:01', 'yyyy-MM-dd'), true);
-insert into posts(id, user_id, title, content, view_count, created_at, is_public) --포스트 3번, 2번보다 오래전--
-values (1000001, 999999, 'testTitle3', 'testContent2', 100, FORMATDATETIME('2023-04-06 00:00:00', 'yyyy-MM-dd'), true);
-insert into posts(id, user_id, title, content, view_count, created_at, is_public) --포스트 4번--
-values (1000002, 999999, 'testTitle4', 'testContent2', 200, FORMATDATETIME('2023-04-06 00:00:01', 'yyyy-MM-dd'), true);
-insert into posts(id, user_id, title, content, view_count, created_at, is_public) --포스트 5번--
-values (1000003, 999999, 'testTitle5', 'testContent2', 5000, FORMATDATETIME('2023-04-06 00:00:02', 'yyyy-MM-dd'), true);
+insert into posts(id, user_id, title, content, view_count, created_at, is_public, description) --포스트 1번, 후순위--
+values (999999, 999999, 'testTitle', 'testContent2', 0, FORMATDATETIME('2023-05-06 00:00:00', 'yyyy-MM-dd'), true,
+        'description1');
+insert into posts(id, user_id, title, content, view_count, created_at, is_public, description) --포스트 2번--
+values (1000000, 999999, 'testTitle2', 'testContent2', 100, FORMATDATETIME('2023-05-06 00:00:01', 'yyyy-MM-dd'), true,
+        'description2');
+insert into posts(id, user_id, title, content, view_count, created_at, is_public, description) --포스트 3번, 2번보다 오래전--
+values (1000001, 999999, 'testTitle3', 'testContent2', 100, FORMATDATETIME('2023-04-06 00:00:00', 'yyyy-MM-dd'), true,
+        'description3');
+insert into posts(id, user_id, title, content, view_count, created_at, is_public, description) --포스트 4번--
+values (1000002, 999999, 'testTitle4', 'testContent2', 200, FORMATDATETIME('2023-04-06 00:00:01', 'yyyy-MM-dd'), true,
+        'description4');
+insert into posts(id, user_id, title, content, view_count, created_at, is_public, description) --포스트 5번--
+values (1000003, 999999, 'testTitle5', 'testContent2', 5000, FORMATDATETIME('2023-04-06 00:00:02', 'yyyy-MM-dd'), true,
+        'description5');
 -- 댓글 --
 insert into comments(id, user_id, post_id, content, depth) --부모 댓글, 포스트 1번--
 values (999999, 999999, 999999, 'testParentComment', 0);


### PR DESCRIPTION
# What is this PR?🔍

⚠️현재 스프린트가 종료된 관계로 Jira의 이슈를 참조할 수 없습니다.

## Changes📝

그동안 401(Unauthorized)과 404(Not Found)에 대해서 반복적인 ApiResponse를 작성한 부분을 SwaggerConfig에서 일괄 적용하도록 리팩토링했습니다. Java의 Reflection을 활용했습니다. 다만 제약 사항이 많아 적용 범위는 제한적입니다.

## Screenshots📸

|기능|스크린샷|
|---|-------|
|image|![image](https://github.com/HBNU-SWUNIV/come-capstone23-f12/assets/57584529/062ad5ba-d978-4437-80b3-417113ecf98b)|

