### PR TITLE
fix: 모든 HTTP 응답에 charset=utf-8이 붙는 오류 수정

### DIFF
--- a/003 Code/BE/notion-linked-blog/src/main/resources/application.yml
+++ b/003 Code/BE/notion-linked-blog/src/main/resources/application.yml
@@ -1,9 +1,3 @@
-# 콘솔에 한글 깨짐 방지
-server:
-  servlet:
-    encoding:
-      force-response: true
-
 spring:
   h2:
     console:


### PR DESCRIPTION
# What is this PR?🔍

- Jira Issues: [F12-93](https://come-capstone23-f12.atlassian.net/browse/F12-93)

## Changes📝

모든 HTTP 응답에 charset=utf-8이 붙는 오류를 수정했습니다.
