### PR TITLE
fix: 로그인 상태 확인 응답으로 Authentication.User -> UserDataRepository.User

### DIFF
--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/security/config/SecurityConfig.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/security/config/SecurityConfig.java
@@ -25,6 +25,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.f12.notionlinkedblog.api.common.Endpoint;
+import io.f12.notionlinkedblog.repository.user.UserDataRepository;
 import io.f12.notionlinkedblog.security.common.dto.AuthenticationFailureDto;
 import io.f12.notionlinkedblog.security.login.ajax.configure.AjaxLoginConfigurer;
 import io.f12.notionlinkedblog.security.login.check.filter.LoginStatusCheckingFilter;
@@ -37,6 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 public class SecurityConfig {
 
 	private final UserDetailsService userDetailsService;
+	private final UserDataRepository userDataRepository;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -83,7 +85,7 @@ public class SecurityConfig {
 			.apply(ajaxLoginConfigurer());
 
 		http
-			.addFilterBefore(new LoginStatusCheckingFilter(), LogoutFilter.class);
+			.addFilterBefore(new LoginStatusCheckingFilter(userDataRepository), LogoutFilter.class);
 
 		return http.build();
 	}

--- a/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/security/login/check/filter/LoginStatusCheckingFilter.java
+++ b/003 Code/BE/notion-linked-blog/src/main/java/io/f12/notionlinkedblog/security/login/check/filter/LoginStatusCheckingFilter.java
@@ -20,6 +20,8 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.f12.notionlinkedblog.domain.user.User;
+import io.f12.notionlinkedblog.repository.user.UserDataRepository;
 import io.f12.notionlinkedblog.security.login.ajax.dto.LoginUser;
 import io.f12.notionlinkedblog.security.login.ajax.dto.UserWithoutPassword;
 import io.f12.notionlinkedblog.security.login.check.dto.LoginStatusCheckingFailureResponseDto;
@@ -32,6 +34,11 @@ public final class LoginStatusCheckingFilter extends OncePerRequestFilter {
 	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	private final RequestMatcher loginStatusCheckingRequestMatcher = new AntPathRequestMatcher(LOGIN_STATUS, "GET");
+	private final UserDataRepository userDataRepository;
+
+	public LoginStatusCheckingFilter(UserDataRepository userDataRepository) {
+		this.userDataRepository = userDataRepository;
+	}
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -47,7 +54,8 @@ public final class LoginStatusCheckingFilter extends OncePerRequestFilter {
 					&& (authentication = securityContext.getAuthentication()) != null) {
 					log.info("SecurityContext is exists.");
 					LoginUser principal = (LoginUser)authentication.getPrincipal();
-					UserWithoutPassword userWithoutPassword = UserWithoutPassword.of(principal.getUser());
+					User user = userDataRepository.findById(principal.getUser().getId()).get();
+					UserWithoutPassword userWithoutPassword = UserWithoutPassword.of(user);
 					LoginStatusCheckingSuccessResponseDto responseDto =
 						LoginStatusCheckingSuccessResponseDto.of(userWithoutPassword);
 					response.setStatus(HttpServletResponse.SC_OK);


### PR DESCRIPTION
# What is this PR?🔍

- Jira Issues: [F12-109](https://come-capstone23-f12.atlassian.net/browse/F12-109)

## Changes📝

Authentication.User는 첫 로그인 시에 대한 User가 들어있으며 User 데이터가 변경되어도 동기화되지 않습니다. 그런데 로그인 상태 확인 API의 응답으로 예전 User가 응답되어 프론트엔드에서 이전 User 데이터를 참조하는 문제가 발생하였습니다. 그래서 직접 UserDataRepository에서 조회하도록 로직을 변경하였습니다.
