### PR TITLE
refactor: useInfiniteScroll의 IntersectionObserver를 useEffect 내부로 이동

### DIFF
--- a/003 Code/FE/notion-linked-blog/src/components/common/AppLayout.tsx
+++ b/003 Code/FE/notion-linked-blog/src/components/common/AppLayout.tsx
@@ -4,13 +4,6 @@ import styled from "styled-components";
 
 const {Content} = Layout;
 
-const StyledLayout = styled(Layout)`
-	display: flex;
-	flex-direction: row;
-	justify-content: center;
-	width: 100%;
-`;
-
 const StyledContent = styled(Content)`
 	display: flex;
 	justify-content: center;
@@ -19,10 +12,10 @@ const StyledContent = styled(Content)`
 
 export default function AppLayout({children}) {
 	return (
-		<StyledLayout>
+		<Layout>
 			<StyledContent>
 				{children}
 			</StyledContent>
-		</StyledLayout>
+		</Layout>
 	);
 }

--- a/003 Code/FE/notion-linked-blog/src/components/post/MainPosts.tsx
+++ b/003 Code/FE/notion-linked-blog/src/components/post/MainPosts.tsx
@@ -29,28 +29,27 @@ export default function MainPosts() {
 	const [isLoading, setIsLoading] = useState(false);
 	const [errorMsg, setErrorMsg] = useState("");
 	const target = useRef(null);
-
-	const {count} = useInfiniteScroll({
+	const [count] = useInfiniteScroll({
 		target,
 		targetArray: mainPosts,
 		threshold: 0.2,
 		endPoint: 3,
 	});
 
-	const fetchPosts = async () => {
-		setIsLoading(true);
-		try {
-			const posts = await loadPostAPI(count);
-
-			setMainPosts([...mainPosts, ...posts]);
-		} catch (e) {
-			setErrorMsg(e.message);
-		} finally {
-			setIsLoading(false);
-		}
-	};
-
 	useEffect(() => {
+		const fetchPosts = async () => {
+			setIsLoading(true);
+			try {
+				const posts = await loadPostAPI(count);
+
+				setMainPosts([...mainPosts, ...posts]);
+			} catch (e) {
+				setErrorMsg(e.message);
+			} finally {
+				setIsLoading(false);
+			}
+		};
+
 		fetchPosts();
 	}, [count]);
 

--- a/003 Code/FE/notion-linked-blog/src/hooks/useInfiniteScroll.ts
+++ b/003 Code/FE/notion-linked-blog/src/hooks/useInfiniteScroll.ts
@@ -1,4 +1,4 @@
-import {useState, useRef, useEffect, useMemo} from "react";
+import {useState, useRef, useEffect} from "react";
 
 export default function useInfiniteScroll({
 	root = null, target, threshold = 1, rootMargin = "0px", targetArray, endPoint = 1,
@@ -6,22 +6,19 @@ export default function useInfiniteScroll({
 	const [count, setCount] = useState(0);
 	const currentChild = useRef(null);
 
-	const intersectionObserver = useMemo(() => new IntersectionObserver(
-		(entries, observer) => {
-			if (target?.current === null) {
-				return;
-			}
-			if (entries[0].isIntersecting) {
-				setCount(v => v + 1);
-				observer.disconnect();
-			}
-		},
-	), [target, root, rootMargin, threshold]);
-
 	useEffect(() => {
 		if (target?.current === null) {
 			return;
 		}
+
+		const intersectionObserver = new IntersectionObserver(
+			(entries, observer) => {
+				if (entries[0].isIntersecting) {
+					setCount(v => v + 1);
+					observer.disconnect();
+				}
+			},
+		);
 
 		const observeChild = target.current.children[target.current.children.length - endPoint];
 
@@ -37,8 +34,8 @@ export default function useInfiniteScroll({
 		};
 	}, [count, targetArray, target, endPoint]);
 
-	return {
+	return [
 		count,
 		setCount,
-	};
+	] as const;
 }

--- a/003 Code/FE/notion-linked-blog/src/pages/_app.tsx
+++ b/003 Code/FE/notion-linked-blog/src/pages/_app.tsx
@@ -1,4 +1,3 @@
-import {useState, useEffect} from "react";
 import wrapper from "@/redux/store";
 import {createGlobalStyle} from "styled-components";
 import AppHeader from "@/components/common/AppHeader";
@@ -21,15 +20,6 @@ const GlobalStyles = createGlobalStyle`
 
 function App({Component, ...rest}) {
 	const {store, props} = wrapper.useWrappedStore(rest);
-	const [hydrate, setHydrate] = useState(false);
-
-	useEffect(() => {
-		setHydrate(true);
-	}, []);
-
-	if (!hydrate) {
-		return null;
-	}
 
 	return (
 		<Provider store={store}>


### PR DESCRIPTION
# What is this PR?🔍

- Jira Issues: [F12-112](https://come-capstone23-f12.atlassian.net/browse/F12-112)

## Changes📝

_app의 useEffect를 제거하고 useInfiniteScroll의 IntersectionObserver를 useEffect 내부로 이동했습니다.

기존에 브라우저 렌더링 전 Next.js 에서 처리하던 SSR 동작 중 IntersectionOberserver 라는 브라우저 API 호출 시 에러가 발생하였습니다. 이를 _app에서 useEffect와 useState를 사용하여 상태를 처리하고 있었습니다. _app은 모든 컴포넌트 호출 시 가장 먼저 실행되는 컴포넌트이기 때문에 기존 방식으로는 모든 컴포넌트에 불필요하게 useEffect를 적용합니다. 따라서 이 문제를 useInfiniteScroll 내부로 가져와서 처리하였습니다.
